### PR TITLE
Readme: Update list formatting, fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The `k8s_root` and `dind` demos do require that the laptop be running some linux
 For both of these examples we are joining the laptop to the kind cluster as a node.
 
 
-Other resources.
+Other resources:
 
-report a vuln [k8s.io/security](k8s.io/security)
-ask questions! [slack.k8s.io](slack.k8s.io) #security and #sig-auth
-cve's are announed as part of the [announce google group](https://groups.google.com/forum/#!forum/kubernetes-announce)
+ - report a vuln [k8s.io/security](https://k8s.io/security)
+ - ask questions! [slack.k8s.io](https://slack.k8s.io) #security and #sig-auth
+ - [CVEs](https://cve.mitre.org/) are announced as part of the [announce google group](https://groups.google.com/forum/#!forum/kubernetes-announce)
 
 
 Any questions or feedback please reach out!


### PR DESCRIPTION
Hi! I've enjoyed seeing you give versions of this talk a couple times and was just taking a peek at the repo. I was confused by how the "other resources" section rendered and realized it was a Markdown rendering problem. Figured it was worth proposing a change.

### before
<img width="863" alt="Screen Shot 2020-02-21 at 10 14 11 AM" src="https://user-images.githubusercontent.com/525265/75060725-38058400-5494-11ea-93bc-27d4182e5926.png">

### after
<img width="522" alt="Screen Shot 2020-02-21 at 10 23 07 AM" src="https://user-images.githubusercontent.com/525265/75060732-3cca3800-5494-11ea-975a-c4d39839c507.png">


### changes
 - Use a Markdown list to prevent GitHub from rendering
list items as one long sentence.
- Fix links to Slack and k8s.io, which were treated as relative
to the repo.
- Link to MITRE CVE site in case the term is unfamiliar.
